### PR TITLE
Reverse initialisation

### DIFF
--- a/PROTOCOL
+++ b/PROTOCOL
@@ -15,6 +15,10 @@ VERSION 1
     [1 Byte] Client Version
     [STRING] Client Name
 
+<= Initialisation
+    [1 Byte] Server Version
+    [STRING] Server Name
+
 One time per file {
     => File Request
         [1 BYTE] Last File ( 0 / 1 )

--- a/dropd/Application.vala
+++ b/dropd/Application.vala
@@ -91,7 +91,7 @@ public class DropDaemon.Application : Granite.Application {
         settings_manager = new Backend.SettingsManager ();
         service_provider = new Backend.ServiceProvider (client, settings_manager);
         service_browser = new Backend.ServiceBrowser (client);
-        server = new Backend.Server ();
+        server = new Backend.Server (settings_manager);
         dbus_interface = new Backend.DBusInterface (server, settings_manager, service_browser);
 
         try {

--- a/dropd/Backend/Server.vala
+++ b/dropd/Backend/Server.vala
@@ -26,14 +26,18 @@ public class DropDaemon.Backend.Server : ThreadedSocketService {
     public signal void new_transmission_interface_registered (string interface_path);
     public signal void transmission_interface_removed (string interface_path);
 
+    private SettingsManager settings_manager;
+
     private DBusConnection dbus_connection;
 
     private TlsCertificate? server_certificate = null;
 
     private uint transmission_counter = 0;
 
-    public Server () {
+    public Server (SettingsManager settings_manager) {
         Object (max_threads : -1);
+
+        this.settings_manager = settings_manager;
 
         Bus.own_name (BusType.SESSION, "org.dropd.IncomingTransmission", BusNameOwnerFlags.NONE, (dbus_connection) => {
             this.dbus_connection = dbus_connection;
@@ -94,9 +98,9 @@ public class DropDaemon.Backend.Server : ThreadedSocketService {
 
                     debug ("Connection established.");
 
-                    protocol_implementation = new IncomingTransmission (tls_connection, true);
+                    protocol_implementation = new IncomingTransmission (tls_connection, settings_manager.get_display_name (), true);
                 } else {
-                    protocol_implementation = new IncomingTransmission (connection, false);
+                    protocol_implementation = new IncomingTransmission (connection, settings_manager.get_display_name (), false);
                 }
 
                 string interface_path = "/org/dropd/IncomingTransmission%u".printf (transmission_counter++);

--- a/lib/Interfaces.vala
+++ b/lib/Interfaces.vala
@@ -127,6 +127,7 @@ namespace Drop {
      */
     public enum ServerState {
         AWAITING_INITIALISATION,
+        SENDING_INITIALISATION,
         AWAITING_REQUEST,
         NEEDS_CONFIRMATION,
         SENDING_CONFIRMATION,
@@ -143,6 +144,7 @@ namespace Drop {
     public enum ClientState {
         LOADING_FILES,
         SENDING_INITIALISATION,
+        AWAITING_INITIALISATION,
         SENDING_REQUEST,
         AWAITING_CONFIRMATION,
         REJECTED,

--- a/lib/Interfaces.vala
+++ b/lib/Interfaces.vala
@@ -195,5 +195,7 @@ namespace Drop {
         public abstract void cancel () throws IOError;
         public abstract bool get_is_secure () throws IOError;
         public abstract ClientState get_state () throws IOError;
+        public abstract uint8 get_server_version () throws IOError;
+        public abstract string get_server_name () throws IOError;
     }
 }

--- a/lib/OutgoingTransmission.vala
+++ b/lib/OutgoingTransmission.vala
@@ -107,6 +107,24 @@ public class Drop.OutgoingTransmission : Object {
         return transmission_bus.get_state ();
     }
 
+    /**
+     * Returns the used protocol version of the connected server.
+     *
+     * @return The protocol version.
+     */
+    public uint8 get_server_version () throws IOError {
+        return transmission_bus.get_server_version ();
+    }
+
+    /**
+     * Returns the display name of the connected server.
+     *
+     * @return The name of the server.
+     */
+    public string get_server_name () throws IOError {
+        return transmission_bus.get_server_name ();
+    }
+
     private void connect_dbus () {
         try {
             transmission_bus = Bus.get_proxy_sync (BusType.SESSION, "org.dropd.OutgoingTransmission", interface_path);


### PR DESCRIPTION
Make the server sinding an initialisation package, too, to tell the client more about the name and protocol version of the server.

**Warning:** This branch introduces a protocol breakage without increasing it's version number. This is necessary, because there is no way for the client to detect if the server supports this second initialisation without this branch. In future this shouldn't and mustn't happen again.

**Note:** The wiki and valadoc needs to be updated after merging this branch!
